### PR TITLE
use setsid when starting process

### DIFF
--- a/templates/lib/lib-nsm-common-utils
+++ b/templates/lib/lib-nsm-common-utils
@@ -935,7 +935,7 @@ process_start()
 
 	# execute application
 	echo "Executing: $APP $APP_OPTIONS" >$LOG_FILE
-	eval exec $APP $APP_OPTIONS >>$LOG_FILE 2>&1 &
+	eval exec setsid $APP $APP_OPTIONS >>$LOG_FILE 2>&1 &
 
 	# grab the PID which should be sufficient majority of the time
 	PID=$!


### PR DESCRIPTION
I'm seeing a strange issue when running nsm_sensor_ps-start from a debian package control script (in securityonion-pfring-module).  The dpkg process creates its own process group, and its own controlling tty, and starts the sensors before exiting.  When it exits, it brings its children down with it, including any processes started here that haven't daemonized themselves.

Adding setsid when exec'ing the process means it starts the process in its own process group without a controlling tty.  It's not a complete substitute for daemonizing the process, but does at least allow it to avoid receiving its parent's SIGHUP when exiting.

Please test this well before rolling it out.  I've only tested a few cases in securityonion, but am not a Linux tty or process group expert and don't know for sure what other implications there might be.  What I've seen, however, is that with this patch, the processes started by these tools do not have a tty listed in their process table listing (eg: ps -ef | grep tclsh), and do not exit with dpkg when started by it.
